### PR TITLE
Update deprecated pyproject.toml poetry section name

### DIFF
--- a/project-template/{{ project_repo_name }}/pyproject.toml
+++ b/project-template/{{ project_repo_name }}/pyproject.toml
@@ -69,7 +69,7 @@ xonsh = ">=0.12.5"
 {% endif %}
 
 {% if package_manager == 'poetry' %}
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"
 {% else %}
 [project.optional-dependencies]


### PR DESCRIPTION
Poetry warns:

> The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.