### PR TITLE
Maintenance: several updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
 #          - macos-latest
 #          - windows-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,11 @@ jobs:
 #          - macos-latest
 #          - windows-latest
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
       - 'v*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     strategy:

--- a/project-template/{{ project_repo_name }}/.github/ISSUE_TEMPLATE/new-issue.md
+++ b/project-template/{{ project_repo_name }}/.github/ISSUE_TEMPLATE/new-issue.md
@@ -1,3 +1,11 @@
+---
+name: New Issue
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
 Hi! Thank you for the awesome xontrib! I gave it a star!
 
 I've found that ...

--- a/project-template/{{ project_repo_name }}/.github/workflows/release-drafter.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/release-drafter.yml
@@ -25,7 +25,7 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/project-template/{{ project_repo_name }}/.github/workflows/release.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/project-template/{{ project_repo_name }}/.github/workflows/release.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/project-template/{{ project_repo_name }}/.github/workflows/test.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/project-template/{{ project_repo_name }}/.github/workflows/test.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/test.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Run tests
       run: |
         xonsh -c "xontrib load {{ project_package_name}}"
-        poetry run pytest
+        {% if package_manager == 'poetry' %}poetry run pytest{% else %}pytest{% endif %}

--- a/project-template/{{ project_repo_name }}/.github/workflows/test.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/test.yml
@@ -16,10 +16,11 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     steps:
     - uses: actions/checkout@v5

--- a/project-template/{{ project_repo_name }}/.github/workflows/test.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/test.yml
@@ -22,14 +22,14 @@ jobs:
           - "3.11"
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 {%- if package_manager == 'poetry' %}
     - name: Install poetry
       run: pipx install poetry
 {% endif -%}
 {% raw %}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }} {% endraw %}
         cache: {% if package_manager == 'poetry' %}poetry{% else %}pip{% endif %}

--- a/project-template/{{ project_repo_name }}/.github/workflows/test.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     strategy:

--- a/project-template/{{ project_repo_name }}/.github/workflows/test.yml
+++ b/project-template/{{ project_repo_name }}/.github/workflows/test.yml
@@ -19,14 +19,14 @@ jobs:
           - "3.11"
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 {%- if package_manager == 'poetry' %}
     - name: Install poetry
       run: pipx install poetry
 {% endif -%}
 {% raw %}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }} {% endraw %}
         cache: {% if package_manager == 'poetry' %}poetry{% else %}pip{% endif %}

--- a/project-template/{{ project_repo_name }}/pyproject.toml
+++ b/project-template/{{ project_repo_name }}/pyproject.toml
@@ -120,7 +120,7 @@ force-exclude = '''
 '''
 
 [tool.ruff]
-select = [
+lint.select = [
     "E",
     "F",
     "B", # flake8-bugbear

--- a/project-template/{{ project_repo_name }}/pyproject.toml
+++ b/project-template/{{ project_repo_name }}/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: System :: System Shells",
     "Topic :: Terminals",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["xonsh>=0.12.5"]
 authors = [
     { name = "{{full_name}}", email = "{{email}}" },
@@ -64,7 +64,7 @@ Code = "https://github.com/{{github_username}}/{{project_repo_name}}"
 
 {% if package_manager == 'poetry' %}
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 xonsh = ">=0.12.5"
 {% endif %}
 

--- a/project-template/{{ project_repo_name }}/pyproject.toml
+++ b/project-template/{{ project_repo_name }}/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: System :: System Shells",
     "Topic :: Terminals",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["xonsh>=0.12.5"]
 authors = [
     { name = "{{full_name}}", email = "{{email}}" },
@@ -64,7 +64,7 @@ Code = "https://github.com/{{github_username}}/{{project_repo_name}}"
 
 {% if package_manager == 'poetry' %}
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.11"
 xonsh = ">=0.12.5"
 {% endif %}
 

--- a/project-template/{{ project_repo_name }}/{% if enable_pre_commit_hooks %}.pre-commit-config.yaml{%endif%}
+++ b/project-template/{{ project_repo_name }}/{% if enable_pre_commit_hooks %}.pre-commit-config.yaml{%endif%}
@@ -10,7 +10,6 @@ repos:
     hooks:
       - id: mypy
         args: [ "--allow-untyped-globals", "--ignore-missing-imports" ]
-        additional_dependencies: [ types-all ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: ""

--- a/project-template/{{ project_repo_name }}/{%if package_manager == 'setuptools' %}setup.py{%endif%}
+++ b/project-template/{{ project_repo_name }}/{%if package_manager == 'setuptools' %}setup.py{%endif%}
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     { name = "Your Name", email = "you@example.com" },
 ]
 license = { text = "MIT" }
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "copier>=9",
     "copier-templates-extensions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     { name = "Your Name", email = "you@example.com" },
 ]
 license = { text = "MIT" }
-requires-python = ">=3.8,<4.0"
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "copier>=9",
     "copier-templates-extensions"

--- a/tests/data.py
+++ b/tests/data.py
@@ -2,7 +2,7 @@ COMMON_FILES = {
     ".copier-answers.yml",
     ".editorconfig",
     ".gitattributes",
-    ".github/issue_template.md",
+    ".github/ISSUE_TEMPLATE/new-issue.md",
     ".github/FUNDING.yml",
     ".github/pull_request_template.md",
     ".github/release-drafter.yml",


### PR DESCRIPTION
The change I'm least sure about is bumping the minimum Python version. I'm not sure what the policy is. But 3.8/9 don't pass CI after `pre-commit autoupdate` pins mypy to 1.20.

Several CI actions warned that they
> run on Node.js 20, which GitHub deprecated and will force-upgrade in June 2026. Bump to current major versions, both of which run on Node.js 24.

`actions/cache@v3` still does but is pulled by `pre-commit/action@v3.0.0` which itself is deprecated. I don't know how to resolve this.

Claude justification for removing `types-all`.
  ▎ types-all is a meta-package that depends on types-pkg-resources, which has been removed from PyPI
  ▎ (its stubs were merged into types-setuptools). Installing the mypy hook fails with No matching
  ▎ distribution found for types-pkg-resources.
  ▎
  ▎ Since the hook already passes --ignore-missing-imports, no replacement is needed. Projects that
  ▎ need specific stubs can add them as additional_dependencies themselves (e.g. types-requests).